### PR TITLE
Fix specs for logger warning

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --colour
 --format=documentation
+--exclude-pattern='spec/integration/**/*_spec.rb'

--- a/spec/hashie/mash_spec.rb
+++ b/spec/hashie/mash_spec.rb
@@ -1,8 +1,11 @@
 require 'spec_helper'
 require 'delegate'
+require 'support/logger'
 
 describe Hashie::Mash do
   subject { Hashie::Mash.new }
+
+  include_context 'with a logger'
 
   it 'inherits from Hash' do
     expect(subject.is_a?(Hash)).to be_truthy
@@ -134,12 +137,10 @@ describe Hashie::Mash do
     expect(subject.type).to eq 'Steve'
   end
 
-  shared_context 'with a logger' do
-    it 'logs a warning when overriding built-in methods' do
-      Hashie::Mash.new('trust' => { 'two' => 2 })
+  it 'logs a warning when overriding built-in methods' do
+    Hashie::Mash.new('trust' => { 'two' => 2 })
 
-      expect(logger_output).to match('Hashie::Mash#trust')
-    end
+    expect(logger_output).to match('Hashie::Mash#trust')
   end
 
   context 'updating' do

--- a/spec/hashie_spec.rb
+++ b/spec/hashie_spec.rb
@@ -2,12 +2,12 @@ require 'spec_helper'
 
 RSpec.describe Hashie do
   describe '.logger' do
-    shared_context 'with a logger' do
-      it 'is available via an accessor' do
-        Hashie.logger.info('Fee fi fo fum')
+    include_context 'with a logger'
 
-        expect(logger_output).to match('Fee fi fo fum')
-      end
+    it 'is available via an accessor' do
+      Hashie.logger.info('Fee fi fo fum')
+
+      expect(logger_output).to match('Fee fi fo fum')
     end
   end
 end

--- a/spec/support/logger.rb
+++ b/spec/support/logger.rb
@@ -1,7 +1,9 @@
 # A shared context that allows you to check the output of Hashie's logger.
 #
 # @example
-#   shared_context 'with a logger' do
+#   include_context 'with a logger'
+#
+#   it 'logs info message' do
 #     Hashie.logger.info 'What is happening in here?!'
 #
 #     expect(logger_output).to match('What is happening in here?!')


### PR DESCRIPTION
* Fix for #381: Use of shared context 'with a logger'
* Fix for #392: Exclude integration specs in rspec (as per exclude pattern in Rakefile)